### PR TITLE
Enable bulk memory operations for Wizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ core:
 		cd crates/core \
 				&& cargo build --release --target=wasm32-wasi\
 				&& cd - \
-				&& wizer --allow-wasi target/wasm32-wasi/release/core.wasm -o crates/cli/engine.wasm
+				&& wizer --allow-wasi --wasm-bulk-memory true target/wasm32-wasi/release/core.wasm -o crates/cli/engine.wasm
 		
 test-ruvy:
 		cargo wasi test --package=core -- --nocapture

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
     let engine = include_bytes!("../engine.wasm");
     let mut wize = Wizer::new();
     wize.allow_wasi(true)?
+        .wasm_bulk_memory(true)
         .inherit_env(true)
         .init_func("load_user_code");
 


### PR DESCRIPTION
Enabling support for bulk memory operations appears to clear up some additional errors I was running into. We're very likely going to need to update Wizer to a newer version than 1.6 for this project as well.