### PR TITLE
Update WASI SDK and add linker flag

### DIFF
--- a/crates/wasm-sys/build.rs
+++ b/crates/wasm-sys/build.rs
@@ -52,6 +52,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=m");
     println!("cargo:rustc-link-lib=static=wasi-emulated-signal");
     println!("cargo:rustc-link-lib=static=wasi-emulated-mman");
+    println!("cargo:rustc-link-lib=static=wasi-emulated-process-clocks");
     println!("cargo:rustc-link-lib=static=c");
     println!("cargo:rustc-link-lib=static=crypt");
     println!("cargo:rustc-link-lib=static=pthread");

--- a/install-wasi-sdk.sh
+++ b/install-wasi-sdk.sh
@@ -22,7 +22,7 @@ set -u
 PATH_TO_SDK="crates/wasm-sys/wasi-sdk"
 if [[ ! -d $PATH_TO_SDK ]]; then
     TMPGZ=$(mktemp)
-    VERSION_MAJOR="12"
+    VERSION_MAJOR="20"
     VERSION_MINOR="0"
     if [[ "$(uname -s)" == "Darwin" ]]; then
         curl --fail --location --silent https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${VERSION_MAJOR}/wasi-sdk-${VERSION_MAJOR}.${VERSION_MINOR}-macos.tar.gz --output $TMPGZ


### PR DESCRIPTION
Updating WASI SDK to version 20. Also we need to add this linker flag to remove the following unexpected function exports which were preventing Wasmtime from instantiating the module:

```wat
  (import "env" "getrusage" (func (;0;) (type 1)))
  (import "env" "times" (func (;1;) (type 27)))
  (import "env" "clock" (func (;2;) (type 28)))
```
