### PR TITLE
Use custom linker for passing source code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "once_cell",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ install cmake`
 
 After all the dependencies are installed, run `make`
 
-## Known limitations
-
-The size of your main ruby program is limited by the max allowable limit for environment variables on your operating system. This is because we use a temporary env var to pass in the contents of the ruby program to the Wasm.
-
 ## Usage
 
 A simple ruby program that prints "Hello world" to stdout

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,8 +12,9 @@ path = "src/main.rs"
 clap = { version = "3.2.23", features = ["derive"] }
 wizer = "3.0.0"
 anyhow = "1.0"
-
-[dev-dependencies]
+wasi-common = "9.0.0"
 wasmtime = "9.0.0"
 wasmtime-wasi = "9.0.0"
-wasi-common = "9.0.0"
+once_cell = "1.18.0"
+
+[dev-dependencies]

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -2,7 +2,7 @@ mod runtime;
 
 use once_cell::sync::OnceCell;
 use runtime::cleanup_ruby;
-use std::env;
+use std::{env, io};
 
 static USER_CODE: OnceCell<String> = OnceCell::new();
 
@@ -18,7 +18,7 @@ pub extern "C" fn load_user_code() {
         runtime::preload_files(preload_path);
     }
 
-    let contents = env::var("RUVY_USER_CODE").unwrap();
+    let contents = io::read_to_string(io::stdin()).unwrap();
     USER_CODE.set(contents).unwrap();
 }
 


### PR DESCRIPTION
Use a custom linker instead of Wizer's built in linker. This allows us to use stdin to pass Ruby source code instead of using an environment variable. It also means we don't need to set environment variables on the current process for Wizer to be able to use them.

It will also hopefully clear up an issue I ran into trying to update Ruvy to Rust 1.72 where the instance created by Wizer couldn't read the Ruby source code from the environment variable that contained the Ruby source code.