### PR TITLE
Update runner label to one with only Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: shopify-ubuntu-latest
+    runs-on: shopify-ubuntu-latest-2
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Apparently `shopify-ubuntu-latest` is a mix of Ubuntu 20.04 and Ubuntu 22.04 machines. `shopify-ubuntu-latest-2` is only Ubuntu 22.04.

![Simpons reference](https://media.tenor.com/e-9o99f4eKYAAAAd/simpsons-dont-bother-calling911.gif)