### PR TITLE
Use OnceLock from stdlib instead of OnceCell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "once_cell",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,5 @@ anyhow = "1.0"
 wasi-common = "9.0.0"
 wasmtime = "9.0.0"
 wasmtime-wasi = "9.0.0"
-once_cell = "1.18.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Switch to using stdlib OnceLock instead of OnceCell. I would've preferred doing this yesterday but we only merged support for a recent enough version of Rust this morning.