### PR TITLE
Specify explicit resolver to remove warning messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ members = [
   "crates/core",
   "crates/cli"
 ]
+
+resolver = "2"


### PR DESCRIPTION
Every invocation of `cargo` results in:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

which crowds the terminal output. So I've opted to use `resolver` = "2"` which is explained in https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2. I think that's the behaviour we want.