### PR TITLE
Update runners on GH Actions to public runners

### DIFF
--- a/.github/workflows/cargo-vet.yml
+++ b/.github/workflows/cargo-vet.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cargo-vet:
     name: cargo_vet
-    runs-on: shopify-ubuntu-latest-2
+    runs-on: ubuntu-latest
     env:
       CARGO_VET_VERSION: 0.8.0
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: shopify-ubuntu-latest-2
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   cla:
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     if: |
       (github.event.issue.pull_request
         && !github.event.issue.pull_request.merged_at


### PR DESCRIPTION
## Description of the change

Use GitHub's public runners for our workflows.

## Why am I making this change?

Since this repo is public, we can now use the public runners.
