### PR TITLE
Fix deprecation warning

### DIFF
--- a/crates/wasm-sys/build.rs
+++ b/crates/wasm-sys/build.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .clang_args(&[
             "-fvisibility=default",
             "--target=wasm32-wasi",


### PR DESCRIPTION
## Description of the change

Just a tweak to how we're initializing bindgen's `CargoCallbacks`.

## Why am I making this change?

I got a warning message while compiling saying to invoke `::new()` instead of what we were doing.