### PR TITLE
Disable reference types since Wizer doesn't support them

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+# Disable reference-types since Wizer (as of version 7.0.0) does not support
+# reference-types.
 [target.wasm32-wasip1]
 runner = "wasmtime"
+rustflags = ["-C", "target-feature=-reference-types"]


### PR DESCRIPTION
## Description of the change

Instructs Cargo not to compile the WASI dylib with reference types.

## Why am I making this change?

Wizer doesn't support reference types so project compilation fails with reference types enabled.
