### PR TITLE
Remove wasi-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,6 @@ dependencies = [
  "clap",
  "criterion",
  "ruby-wasm-assets",
- "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
  "wizer",
@@ -2282,32 +2281,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasi-common"
-version = "23.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c19d0b2b2f88ef39e8f5fd0e29e8b00d129e0824cc8c06d2caf9866a6a72b6b"
-dependencies = [
- "anyhow",
- "bitflags 2.5.0",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "log",
- "once_cell",
- "rustix",
- "system-interface",
- "thiserror",
- "tracing",
- "wasmtime",
- "wiggle",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "wasm-bindgen"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,7 +12,6 @@ path = "src/main.rs"
 clap = { version = "4.5.27", features = ["derive"] }
 wizer = "7.0.0"
 anyhow = { workspace = true }
-wasi-common = "23"
 wasmtime = "23"
 wasmtime-wasi = "23"
 


### PR DESCRIPTION
## Description of the change

Removes `wasi-common` crate and replaces uses with `wasmtime-wasi`.

Note that the `.to_vec()` calls introduced in this PR were already happening inside the implementation of `ReadPipe::from`.

## Why am I making this change?

We want to standardize on using `wasmtime-wasi`.