### PR TITLE
Output Ruby VM errors to stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "clap",
  "criterion",
  "ruby-wasm-assets",
+ "tempfile",
  "wasmtime",
  "wasmtime-wasi",
  "wizer",
@@ -441,6 +442,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ruvy-wasm-sys",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ wasmtime-wasi = "31"
 [dev-dependencies]
 criterion = "0.6.0"
 ruby-wasm-assets = { path = "../ruby-wasm-assets" }
+tempfile = "3.0"
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -114,9 +114,8 @@ pub fn test_preload_error_handling() -> Result<()> {
 
     let stderr_str = String::from_utf8_lossy(&output.stderr);
 
-    // Check that we get a wizer initialization error or process failure
     assert!(
-        !output.status.success() || stderr_str.contains("wizer.initialize"),
+        !output.status.success(),
         "Expected ruvy to fail with preload error. Status: {:?}, Stderr: {}",
         output.status,
         stderr_str

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -131,7 +131,13 @@ pub fn test_preload_error_handling() -> Result<()> {
 
     assert!(
         !output.status.success(),
-        "Expected ruvy to fail with preload error. Status: {:?}, Stderr: {}",
+        "Expected preload status to be nonzero. Status: {:?}, Stderr: {}",
+        output.status,
+        stderr_str
+    );
+    assert!(
+        stderr_str.contains("intentional preload error"),
+        "Expected preload stderr to contain Ruby exception. Status: {:?}, Stderr: {}",
         output.status,
         stderr_str
     );
@@ -145,14 +151,13 @@ pub fn test_ruby_runtime_error_in_wasm_execution() -> Result<()> {
     let temp_path = temp_file.path();
 
     let wasm_path = wasm_path("runtime_error");
-    // The compilation should succeed - the error happens at runtime
     run_ruvy(&wasm_path, &temp_path.to_string_lossy(), None)?;
 
-    // The error should be caught when we try to run the WASM
-    let result = run_wasm(&wasm_path, "");
+    let output = run_wasm(&wasm_path, "")?;
     assert!(
-        result.is_err(),
-        "Expected WASM execution to fail with Ruby runtime error"
+        output.stderr.contains("This is a runtime error"),
+        "Expected runtime stderr to contain Ruby exception. Stderr: {}",
+        output.stderr
     );
     Ok(())
 }

--- a/crates/cli/tests/integration_test.rs
+++ b/crates/cli/tests/integration_test.rs
@@ -1,6 +1,10 @@
 use std::{env, path::Path, process::Command, str};
 
 use anyhow::{bail, Result};
+use std::fs;
+use std::io::Write;
+use tempfile::NamedTempFile;
+use tempfile::TempDir;
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{
     pipe::{MemoryInputPipe, MemoryOutputPipe},
@@ -93,11 +97,6 @@ fn run_wasm(wasm_path: impl AsRef<Path>, input: &str) -> Result<String> {
 
 #[test]
 pub fn test_preload_error_handling() -> Result<()> {
-    use std::fs;
-    use std::io::Write;
-    use std::process::Command;
-    use tempfile::TempDir;
-
     let temp_dir = TempDir::new()?;
     let invalid_file = temp_dir.path().join("invalid.rb");
     let mut file = fs::File::create(&invalid_file)?;
@@ -127,9 +126,6 @@ pub fn test_preload_error_handling() -> Result<()> {
 
 #[test]
 pub fn test_ruby_runtime_error_in_wasm_execution() -> Result<()> {
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
     let mut temp_file = NamedTempFile::new()?;
     writeln!(temp_file, "raise 'This is a runtime error'")?;
     let temp_path = temp_file.path();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 ruvy-wasm-sys = { path = "../wasm-sys" }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -18,7 +18,10 @@ pub extern "C" fn load_user_code() {
     runtime::init_ruby();
 
     if let Ok(preload_path) = env::var("RUVY_PRELOAD_PATH") {
-        runtime::preload_files(preload_path);
+        if let Err(e) = runtime::preload_files(preload_path) {
+            eprintln!("Failed to preload files: {}", e);
+            std::process::exit(1);
+        }
     }
 
     let contents = io::read_to_string(io::stdin()).unwrap();

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -7,7 +7,9 @@ static USER_CODE: OnceLock<String> = OnceLock::new();
 
 fn main() {
     let code = USER_CODE.get().unwrap();
-    runtime::eval(code).unwrap();
+    if let Err(e) = runtime::eval(code) {
+        eprintln!("{}", e);
+    }
     cleanup_ruby().unwrap();
 }
 

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -21,8 +21,8 @@ pub extern "C" fn load_user_code() {
 
     if let Ok(preload_path) = env::var("RUVY_PRELOAD_PATH") {
         if let Err(e) = runtime::preload_files(preload_path) {
-            eprintln!("Failed to preload files: {}", e);
-            std::process::exit(1);
+            eprintln!("{}", e);
+            return;
         }
     }
 

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -11,18 +11,18 @@ use std::{
     os::raw::c_char,
 };
 
-fn extract_ruby_error() -> String {
+fn extract_ruby_error() -> Option<String> {
     unsafe {
         let error_obj = rb_errinfo();
         if error_obj == RUBY_Qnil {
-            return "Unknown Ruby error".to_string();
+            return None;
         }
 
         let error_string = rb_obj_as_string(error_obj);
         let mut error_val = error_string;
         let error_ptr = rb_string_value_ptr(&mut error_val);
         if error_ptr.is_null() {
-            return "Failed to extract error message".to_string();
+            return None;
         }
 
         let error_cstr = CStr::from_ptr(error_ptr);
@@ -31,7 +31,7 @@ fn extract_ruby_error() -> String {
         // Clear the error info to prevent it from affecting subsequent operations
         rb_set_errinfo(RUBY_Qnil);
 
-        error_msg
+        Some(error_msg)
     }
 }
 

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -2,8 +2,8 @@ use std::fs;
 
 use anyhow::{anyhow, bail, Result};
 use ruvy_wasm_sys::{
-    rb_errinfo, rb_eval_string_protect, rb_obj_as_string, rb_set_errinfo, rb_string_value_ptr,
-    ruby_init, ruby_init_loadpath, RUBY_Qnil, VALUE,
+    rb_errinfo, rb_eval_string_protect, rb_obj_as_string, rb_string_value_ptr, ruby_init,
+    ruby_init_loadpath, RUBY_Qnil, VALUE,
 };
 use std::{
     ffi::{CStr, CString},
@@ -27,9 +27,6 @@ fn extract_ruby_error() -> Option<String> {
 
         let error_cstr = CStr::from_ptr(error_ptr);
         let error_msg = error_cstr.to_string_lossy().into_owned();
-
-        // Clear the error info to prevent it from affecting subsequent operations
-        rb_set_errinfo(RUBY_Qnil);
 
         Some(error_msg)
     }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -104,7 +104,6 @@ mod tests {
     fn test_extract_ruby_error_with_syntax_error() {
         init_ruby();
         let result = eval("1 + + 1");
-        assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Ruby evaluation failed"));
     }
@@ -113,7 +112,6 @@ mod tests {
     fn test_extract_ruby_error_with_name_error() {
         init_ruby();
         let result = eval("undefined_variable");
-        assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Ruby evaluation failed"));
     }
@@ -122,7 +120,6 @@ mod tests {
     fn test_extract_ruby_error_with_runtime_error() {
         init_ruby();
         let result = eval("raise 'custom error message'");
-        assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Ruby evaluation failed"));
         assert!(error_msg.contains("custom error message"));
@@ -131,7 +128,6 @@ mod tests {
     #[test]
     fn test_preload_files_with_nonexistent_directory() {
         let result = preload_files("/nonexistent/directory".to_string());
-        assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Failed to read preload directory"));
     }
@@ -150,7 +146,6 @@ mod tests {
         writeln!(file, "1 + + 1").unwrap();
 
         let result = preload_files(temp_dir.path().to_string_lossy().to_string());
-        assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Failed to evaluate preload file"));
     }
@@ -172,7 +167,6 @@ mod tests {
         assert!(result.is_ok());
 
         let check_result = eval("$test_var");
-        assert!(check_result.is_ok());
         let value = unsafe { rb_num2int(check_result.unwrap()) };
         assert_eq!(value, 42);
     }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -62,9 +62,7 @@ pub fn preload_files(path: String) -> Result<()> {
         .map_err(|e| anyhow!("Failed to read preload directory '{}': {}", path, e))?;
 
     for entry in entries {
-        let entry = entry.map_err(|e| anyhow!("Failed to read directory entry: {}", e))?;
-        let path = entry.path();
-
+        let path = entry?.path();
         if path.is_file() {
             let prelude_contents = fs::read_to_string(&path)
                 .map_err(|e| anyhow!("Failed to read file '{}': {}", path.display(), e))?;

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -49,11 +49,10 @@ pub fn eval(code: &str) -> Result<VALUE> {
         Ok(result)
     } else {
         let error_msg = extract_ruby_error();
-        let _ = writeln!(io::stderr(), "Ruby Error: {}", error_msg);
         Err(anyhow!(
-            "Ruby evaluation failed with state {}: {}",
+            "Error evaluating Ruby code. State: {}, message: {}",
             state,
-            error_msg
+            error_msg.as_deref().unwrap_or("None")
         ))
     }
 }

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -7,7 +7,6 @@ use ruvy_wasm_sys::{
 };
 use std::{
     ffi::{CStr, CString},
-    io::{self, Write},
     os::raw::c_char,
 };
 
@@ -92,6 +91,9 @@ pub fn cleanup_ruby() -> Result<()> {
 mod tests {
     use super::*;
     use ruvy_wasm_sys::rb_num2int;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::TempDir;
 
     #[test]
     fn test_int() {
@@ -134,10 +136,6 @@ mod tests {
 
     #[test]
     fn test_preload_files_with_invalid_ruby_file() {
-        use std::fs;
-        use std::io::Write;
-        use tempfile::TempDir;
-
         init_ruby();
 
         let temp_dir = TempDir::new().unwrap();
@@ -152,10 +150,6 @@ mod tests {
 
     #[test]
     fn test_preload_files_with_valid_ruby_file() {
-        use std::fs;
-        use std::io::Write;
-        use tempfile::TempDir;
-
         init_ruby();
 
         let temp_dir = TempDir::new().unwrap();

--- a/crates/core/src/runtime.rs
+++ b/crates/core/src/runtime.rs
@@ -70,14 +70,8 @@ pub fn preload_files(path: String) -> Result<()> {
                 .map_err(|e| anyhow!("Failed to read file '{}': {}", path.display(), e))?;
 
             if let Err(e) = eval(&prelude_contents) {
-                let _ = writeln!(
-                    io::stderr(),
-                    "Error in preload file '{}': {}",
-                    path.display(),
-                    e
-                );
                 return Err(e.context(format!(
-                    "Failed to evaluate preload file: {}",
+                    "Failed to evaluate preload file '{}'",
                     path.display()
                 )));
             }

--- a/crates/wasm-sys/src/lib.rs
+++ b/crates/wasm-sys/src/lib.rs
@@ -6,8 +6,4 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-// Re-export Ruby special constants with shorter names for compatibility
 pub const RUBY_Qnil: VALUE = ruby_special_consts_RUBY_Qnil as VALUE;
-pub const RUBY_Qfalse: VALUE = ruby_special_consts_RUBY_Qfalse as VALUE;
-pub const RUBY_Qtrue: VALUE = ruby_special_consts_RUBY_Qtrue as VALUE;
-pub const RUBY_Qundef: VALUE = ruby_special_consts_RUBY_Qundef as VALUE;

--- a/crates/wasm-sys/src/lib.rs
+++ b/crates/wasm-sys/src/lib.rs
@@ -5,3 +5,9 @@
 #![allow(clippy::all)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+// Re-export Ruby special constants with shorter names for compatibility
+pub const RUBY_Qnil: VALUE = ruby_special_consts_RUBY_Qnil as VALUE;
+pub const RUBY_Qfalse: VALUE = ruby_special_consts_RUBY_Qfalse as VALUE;
+pub const RUBY_Qtrue: VALUE = ruby_special_consts_RUBY_Qtrue as VALUE;
+pub const RUBY_Qundef: VALUE = ruby_special_consts_RUBY_Qundef as VALUE;

--- a/ruby_examples/raise_error.rb
+++ b/ruby_examples/raise_error.rb
@@ -1,0 +1,1 @@
+raise "Something went wrong!"


### PR DESCRIPTION
## Description of the change

Address the README contribution bullet "Output any error messages from the Ruby VM on the standard error stream."

I am new to this project and used Claude to help me get familiar and implement the change.